### PR TITLE
Support manual content input for summarization fallback

### DIFF
--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -221,6 +221,7 @@ ${selectedHatData.prompt}`;
   );
 
   const handleClose = useCallback(() => {
+    setIsCapturing(false);
     setArticleContent('');
     setArticleTitle('');
     setContentType(null);
@@ -538,6 +539,20 @@ ${selectedHatData.prompt}`;
             pageType={pageType}
             isCapturing={isCapturing}
             onSummarize={options => {
+              if (options?.manualContent) {
+                setIsCapturing(true);
+                setHasContent(true);
+                setThreadData(null);
+                setMessages([]);
+                setOriginalUrl('');
+                setFormattedUrl('');
+                setArticleContent(options.manualContent);
+                setOriginalContent(options.manualContent);
+                setArticleTitle('');
+                setContentType('article');
+                handleAskAssistant(options.manualContent, true);
+                return;
+              }
               setIsCapturing(true);
               if (!options?.reloadPage) {
                 if (options?.selection) {


### PR DESCRIPTION
### **User description**
This PR adds a fallback UI for users to paste their own content when the content‑script fails to extract page data:

- ZeroState.tsx
  - Import React hooks correctly.
  - Extend `onSummarize` API to accept a `manualContent` parameter.
  - Reposition “Summarize current page” button and a fixed‑height textarea (rows=8) at the top.
  - Add a “Summarize custom content” button beneath the textarea.
- SidePanel.tsx
  - Detect `options.manualContent`, reset all previous states (hasContent, threadData, messages, URLs, etc.), set `articleContent`/`originalContent` to the pasted text, and invoke `handleAskAssistant` directly.
- UI/UX tweaks
  - Change container alignment to top‑start.
  - Ensure full‑width buttons and textarea for consistency.

With these changes, users can always proceed by manually supplying content for summarization.  

Related to https://github.com/josephj/chuchuchu/issues/22#issuecomment-2823097792

Please review and let me know if any adjustments are needed.


___

### **PR Type**
Enhancement


___

### **Description**
- Add manual content input as a fallback for summarization
  - Users can paste custom content if page extraction fails
  - New textarea and button for manual summarization in UI

- Reset summarization state when manual content is used

- UI/UX improvements for button and layout consistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SidePanel.tsx</strong><dd><code>Add and handle manual content input for summarization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/side-panel/src/SidePanel.tsx

<li>Handle manual content input for summarization fallback<br> <li> Reset all summarization states when manual content is used<br> <li> Ensure proper state reset on close


</details>


  </td>
  <td><a href="https://github.com/josephj/chuchuchu/pull/34/files#diff-32ec4a2bcad05b3464aa76b66d7e8864161569814e0c4a5dedf9ab95e0e79295">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZeroState.tsx</strong><dd><code>Add UI for manual content summarization fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/side-panel/src/components/ZeroState.tsx

<li>Add textarea and button for manual content input<br> <li> Extend onSummarize API to accept manualContent<br> <li> Adjust layout for top alignment and full-width controls<br> <li> Improve user guidance for unsupported/readability-checked pages


</details>


  </td>
  <td><a href="https://github.com/josephj/chuchuchu/pull/34/files#diff-b191fdeeef70bd927e82aaf767cf69cb71921c625d537a73438d608f2d436bd0">+29/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>